### PR TITLE
remove redundant "import time"

### DIFF
--- a/qcodes/instrument_drivers/Andor/DU401.py
+++ b/qcodes/instrument_drivers/Andor/DU401.py
@@ -2,7 +2,6 @@ from qcodes import Instrument, Parameter
 from qcodes.utils.validators import Ints
 from qcodes.utils.helpers import create_on_off_val_mapping
 import ctypes
-import time
 
 
 class atmcd64d:


### PR DESCRIPTION
fix: Remove redundant "import time"

time package was not used and therefore removed

no breaking changes